### PR TITLE
Fix currency price regex group usage

### DIFF
--- a/my_libs/currency/chat_analysis.py
+++ b/my_libs/currency/chat_analysis.py
@@ -61,7 +61,7 @@ def display_chat_messages(chat_file):
             price_match = filter_re.search(message)
             if date_match and price_match:
                 date = date_match.group(0)
-                price_raw = price_match.group(2).replace(',', '.').replace('^', '.').replace('р', '.').replace(' ', '.')
+                price_raw = price_match.group(1).replace(',', '.').replace('^', '.').replace('р', '.').replace(' ', '.')
                 try:
                     price = f'{float(price_raw):.2f}'  # Форматируем цену с двумя десятичными знаками
                     dates_and_prices.append((date, price))

--- a/my_libs/currency/main.py
+++ b/my_libs/currency/main.py
@@ -1,4 +1,5 @@
 import chat_analysis
+
 if __name__ == '__main__':
     chat_analysis.start_export()
     raw_price_list = chat_analysis.analyze_main()


### PR DESCRIPTION
## Summary
- fix price group index when extracting values
- tidy currency main script formatting

## Testing
- `python -m py_compile my_libs/currency/main.py my_libs/currency/chat_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_684d322451e4832784350d017b2f3e6d