### PR TITLE
Add channel testing helpers

### DIFF
--- a/my_libs/currency/channel_tester.py
+++ b/my_libs/currency/channel_tester.py
@@ -1,0 +1,36 @@
+from configparser import ConfigParser
+import os
+from telethon import TelegramClient
+
+
+def _get_client():
+    """Create TelegramClient using credentials from config.ini."""
+    config_path = os.path.join(os.path.dirname(__file__), 'config.ini')
+    config = ConfigParser()
+    config.read(config_path)
+    api_id = config.getint('telegram', 'api_id')
+    api_hash = config.get('telegram', 'api_hash')
+    session_name = config.get('telegram', 'session_name')
+    return TelegramClient(session_name, api_id, api_hash)
+
+
+async def test_channel_by_id(channel_id: int):
+    """Return channel info and last 5 messages for the given channel ID."""
+    async with _get_client() as client:
+        entity = await client.get_entity(channel_id)
+        messages = []
+        async for message in client.iter_messages(entity, limit=5):
+            messages.append(message.message or '')
+        return entity.to_dict(), messages
+
+
+async def test_channel_by_username(username: str):
+    """Return channel info and last 5 messages for the given @username."""
+    if not username.startswith('@'):
+        username = '@' + username
+    async with _get_client() as client:
+        entity = await client.get_entity(username)
+        messages = []
+        async for message in client.iter_messages(entity, limit=5):
+            messages.append(message.message or '')
+        return entity.to_dict(), messages

--- a/my_libs/currency/chat_analysis.py
+++ b/my_libs/currency/chat_analysis.py
@@ -94,9 +94,11 @@ async def export_messages(chat_id, chat_name):
 
     all_messages = []
 
+    entity = await client.get_input_entity(chat_id)
+
     while True:
         history = await client(GetHistoryRequest(
-            peer=chat_id,
+            peer=entity,
             offset_id=offset_id,
             offset_date=None,
             add_offset=0,


### PR DESCRIPTION
## Summary
- create channel_tester utilities for checking Telegram channel info
- fix chat export by resolving channel ID to input entity

## Testing
- `python -m py_compile handlers/users/purchase.py`
- `python -m py_compile my_libs/currency/channel_tester.py`
- `python -m py_compile my_libs/currency/chat_analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3637d76c832795af43c18c242e60