### PR TITLE
Ensure BOT_TOKEN configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Telegram Bot
+
+This project contains a Telegram bot and related helper scripts.
+
+## `private_data/` directory
+
+Configuration files containing private data such as bot tokens are stored in the `private_data/` folder. This directory is excluded from version control via `.gitignore` so that credentials do not get committed.
+
+Place your `.env` file inside `private_data/`. It may define the following variables:
+
+```
+BOT_TOKEN=<token used on Linux/macOS>
+BOT_TOKEN_WIN=<token used on Windows>
+```
+
+At least one of these tokens must be present for the bot to start. The `config.py` file loads this `.env` file automatically.

--- a/config.py
+++ b/config.py
@@ -6,7 +6,12 @@ import platform
 BASE_DIR = Path(__file__).resolve().parent
 PRIVATE_DIR = BASE_DIR / 'private_data'
 
+# Load environment variables from the optional private directory
 load_dotenv(PRIVATE_DIR / '.env')
+
+# Ensure that at least one bot token is provided
+if not (os.getenv('BOT_TOKEN') or os.getenv('BOT_TOKEN_WIN')):
+    raise RuntimeError('BOT_TOKEN not configured')
 
 if platform.processor() == 'Intel64 Family 6 Model 42 Stepping 7, GenuineIntel':
     BOT_TOKEN = os.getenv("BOT_TOKEN_WIN")


### PR DESCRIPTION
## Summary
- check for missing BOT_TOKEN in `config.py`
- document usage of `private_data/.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688208eb2f9c8327935174c2e80d58eb