### PR TITLE
Improve BOT_TOKEN check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Telegram Bot
+
+This project contains a Telegram bot and related helper scripts.
+
+## `private_data/` directory
+
+Configuration files containing private data such as bot tokens are stored in the `private_data/` folder. This directory is excluded from version control via `.gitignore` so that credentials do not get committed.
+
+Place your `.env` file inside `private_data/`. It may define the following variables:
+
+```
+BOT_TOKEN=<token used on Linux/macOS>
+BOT_TOKEN_WIN=<token used on Windows>
+```
+At least one of these tokens must be present for the bot to start. The
+`config.py` file loads this `.env` file automatically. Whichever token is set
+will be used; if both are provided the one appropriate for the current
+platform is chosen.

--- a/config.py
+++ b/config.py
@@ -6,9 +6,20 @@ import platform
 BASE_DIR = Path(__file__).resolve().parent
 PRIVATE_DIR = BASE_DIR / 'private_data'
 
+# Load environment variables from the optional private directory
 load_dotenv(PRIVATE_DIR / '.env')
 
+bot_token = os.getenv('BOT_TOKEN')
+bot_token_win = os.getenv('BOT_TOKEN_WIN')
+
+# Ensure that at least one bot token is provided
+if not (bot_token or bot_token_win):
+    raise RuntimeError('BOT_TOKEN not configured')
+
 if platform.processor() == 'Intel64 Family 6 Model 42 Stepping 7, GenuineIntel':
-    BOT_TOKEN = os.getenv("BOT_TOKEN_WIN")
+    BOT_TOKEN = bot_token_win or bot_token
 else:
-    BOT_TOKEN = os.getenv("BOT_TOKEN")
+    BOT_TOKEN = bot_token or bot_token_win
+
+if not BOT_TOKEN:
+    raise RuntimeError('BOT_TOKEN not configured for this platform')


### PR DESCRIPTION
## Summary
- improve BOT_TOKEN check after loading .env
- clarify README with token usage across platforms

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688208eb2f9c8327935174c2e80d58eb