### PR TITLE
Organize YouTube MP3 parser into submodule

### DIFF
--- a/my_libs/youtube/youtube_parser_MP3.py
+++ b/my_libs/youtube/youtube_parser_MP3.py
@@ -1,6 +1,5 @@
 import os
 import yt_dlp
-from pydub import AudioSegment
 
 def download_youtube_audio(url):
     try:
@@ -27,5 +26,7 @@ def download_youtube_audio(url):
     except Exception as e:
         print(f"An error occurred: {e}")
 
-# Пример использования
-download_youtube_audio("https://www.youtube.com/watch?v=sXC6AUbY69A&t=14179s")
+if __name__ == "__main__":
+    download_youtube_audio(
+        "https://www.youtube.com/watch?v=sXC6AUbY69A&t=14179s"
+    )


### PR DESCRIPTION
## Summary
- move YouTube MP3 parser into `my_libs/youtube` folder
- add `__main__` guard to sample usage and drop unused import

## Testing
- `python -m py_compile my_libs/youtube/youtube_parser_MP3.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689326eb928c8327a270f783fa15530b