### PR TITLE
Use pathlib for cross-platform paths

### DIFF
--- a/handlers/users/purchase.py
+++ b/handlers/users/purchase.py
@@ -34,6 +34,7 @@ from loader import dp, bot
 from my_libs.libs_selenium import create_chrome_driver_object
 import asyncio
 from configparser import ConfigParser
+from pathlib import Path
 from telethon import TelegramClient
 
 ti = 0
@@ -340,12 +341,15 @@ async def add_currency_chat(message: types.Message):
 
     from config import PRIVATE_DIR
     config = ConfigParser()
-    config.read(os.path.join(PRIVATE_DIR, 'currency_config.ini'))
+    config_path = PRIVATE_DIR / 'currency_config.ini'
+    config.read(config_path)
     api_id = config.getint('telegram', 'api_id')
     api_hash = config.get('telegram', 'api_hash')
     session_name = config.get('telegram', 'session_name')
+    session_path = Path(PRIVATE_DIR) / session_name
+    session_path.parent.mkdir(parents=True, exist_ok=True)
 
-    async with TelegramClient(session_name, api_id, api_hash) as tg_client:
+    async with TelegramClient(str(session_path), api_id, api_hash) as tg_client:
         try:
             entity = await tg_client.get_entity(channel)
         except Exception as e:
@@ -354,9 +358,9 @@ async def add_currency_chat(message: types.Message):
         chat_id = entity.id
         chat_name = entity.title
 
-    chats_file = 'my_libs/currency/data/chats.txt'
+    chats_file = Path(__file__).resolve().parents[2] / 'my_libs' / 'currency' / 'data' / 'chats.txt'
     try:
-        with open(chats_file, 'r', encoding='utf-8') as f:
+        with chats_file.open('r', encoding='utf-8') as f:
             lines = [line.strip() for line in f if line.strip()]
     except FileNotFoundError:
         lines = []
@@ -366,7 +370,7 @@ async def add_currency_chat(message: types.Message):
         await message.answer('Канал уже есть в списке.')
         return
 
-    with open(chats_file, 'a', encoding='utf-8') as f:
+    with chats_file.open('a', encoding='utf-8') as f:
         f.write(f'{chat_id} - {chat_name}\n')
 
     await message.answer(f'Канал {chat_name} добавлен в список.')
@@ -510,7 +514,7 @@ async def waiting_for_new_link(message: Message, state: FSMContext):
         await message.answer(text=f'{file_name} успешно загружен')
     elif file_name.split('.')[-1] == 'pkl':
         from config import PRIVATE_DIR
-        dest = os.path.join(PRIVATE_DIR, 'cookies', 'test_cookies.pkl')
+        dest = PRIVATE_DIR / 'cookies' / 'test_cookies.pkl'
         await message.document.download(destination_file=dest)
         await message.answer(text=f'{file_name} успешно загружен')
     elif file_name.split('.')[-1] == 'xlsx':

--- a/my_libs/currency/channel_tester.py
+++ b/my_libs/currency/channel_tester.py
@@ -1,18 +1,20 @@
 from configparser import ConfigParser
-import os
+from pathlib import Path
 from config import PRIVATE_DIR
 from telethon import TelegramClient
 
 
 def _get_client():
     """Create TelegramClient using credentials from config.ini."""
-    config_path = os.path.join(PRIVATE_DIR, 'currency_config.ini')
+    config_path = PRIVATE_DIR / 'currency_config.ini'
     config = ConfigParser()
     config.read(config_path)
     api_id = config.getint('telegram', 'api_id')
     api_hash = config.get('telegram', 'api_hash')
     session_name = config.get('telegram', 'session_name')
-    return TelegramClient(session_name, api_id, api_hash)
+    session_path = Path(PRIVATE_DIR) / session_name
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    return TelegramClient(str(session_path), api_id, api_hash)
 
 
 async def test_channel_by_id(channel_id: int):

--- a/my_libs/currency/chat_analysis.py
+++ b/my_libs/currency/chat_analysis.py
@@ -1,6 +1,6 @@
-import os
 import re
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from telethon import TelegramClient
 from telethon.tl.functions.messages import GetHistoryRequest
 from configparser import ConfigParser
@@ -19,8 +19,9 @@ logging.basicConfig(
 )
 
 # Путь к папке data
-data_dir = 'data'
-chats_file = os.path.join(data_dir, 'chats.txt')
+BASE_DIR = Path(__file__).resolve().parent
+data_dir = BASE_DIR / 'data'
+chats_file = data_dir / 'chats.txt'
 
 # Регулярное выражение для определения начала нового сообщения (дата и время в формате YYYY-MM-DD HH:MM:SS UTC)
 message_start_re = re.compile(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC')
@@ -124,13 +125,13 @@ async def export_messages(chat_id, chat_name):
             break
 
     # Сохраняем сообщения в файл, добавляя новые записи
-    chat_file = os.path.join(data_dir, f'{chat_name}.txt')
+    chat_file = data_dir / f'{chat_name}.txt'
     existing_lines = set()
-    if os.path.exists(chat_file):
-        with open(chat_file, 'r', encoding='utf-8') as f:
+    if chat_file.exists():
+        with chat_file.open('r', encoding='utf-8') as f:
             existing_lines = {line.strip() for line in f if line.strip()}
 
-    with open(chat_file, 'a', encoding='utf-8') as f:
+    with chat_file.open('a', encoding='utf-8') as f:
         for message in all_messages:
             text = (message.message or '').replace('\n', ' ').replace('\r', ' ')
             line = f"{message.date.strftime('%Y-%m-%d %H:%M:%S %Z')} - {message.sender_id}: {text}"
@@ -151,12 +152,12 @@ async def export_main():
 # Главная функция для отображения сообщений из всех файлов чатов
 def analyze_main():
     # Проверяем, существует ли папка data
-    if not os.path.exists(data_dir):
+    if not data_dir.exists():
         print("Папка data не существует. Убедитесь, что папка data и файлы с сообщениями чатов существуют.")
         return
 
     # Получаем список файлов в папке data
-    chat_files = [f for f in os.listdir(data_dir) if f.endswith('.txt')]
+    chat_files = [f.name for f in data_dir.glob('*.txt')]
 
     if not chat_files:
         print("Нет файлов с сообщениями чатов в папке data.")
@@ -165,7 +166,7 @@ def analyze_main():
     # Читаем и отображаем сообщения из каждого файла
     for chat_file in chat_files:
         print(f"\nСообщения из чата: {chat_file}")
-        display_chat_messages(os.path.join(data_dir, chat_file))
+        display_chat_messages(data_dir / chat_file)
 
     # Сортируем список дат и цен
     sorted_dates_and_prices = sorted(dates_and_prices, key=lambda x: datetime.strptime(x[0], '%Y-%m-%d %H:%M:%S UTC'))
@@ -177,15 +178,15 @@ def analyze_main():
 
     # Записываем все отфильтрованные сообщения в отдельный файл,
     # сортируя их по дате от старых к новым и помечая используемую цену
-    messages_file = os.path.join(data_dir, 'used_messages.txt')
+    messages_file = data_dir / 'used_messages.txt'
 
     def strip_price_tag(line):
         """Удаляем ранее добавленную отметку цены в конце сообщения."""
         return re.sub(r'\s\[\d{2,3}(?:\.\d{2})?\]$', '', line)
 
     existing_lines = []
-    if os.path.exists(messages_file):
-        with open(messages_file, 'r', encoding='utf-8') as f:
+    if messages_file.exists():
+        with messages_file.open('r', encoding='utf-8') as f:
             existing_lines = [strip_price_tag(l.strip()) for l in f if l.strip()]
 
     existing_set = set(existing_lines)
@@ -214,7 +215,7 @@ def analyze_main():
                 return line
         return line
 
-    with open(messages_file, 'w', encoding='utf-8') as f:
+    with messages_file.open('w', encoding='utf-8') as f:
         for line in existing_lines:
             f.write(annotate_price(line) + '\n')
     return sorted_dates_and_prices
@@ -251,7 +252,7 @@ def calculate_daily_average(prices):
 
 def update_currency_rates(dates_and_rates):
     # Путь к файлу с курсами валют
-    currency_file = 'data/currency.txt'
+    currency_file = data_dir / 'currency.txt'
 
     # Функция для получения курса ЦБ РФ на указанную дату
     def get_cbr_rate(date):
@@ -265,8 +266,8 @@ def update_currency_rates(dates_and_rates):
         return None
 
     # Чтение существующего файла с курсами
-    if os.path.exists(currency_file):
-        with open(currency_file, 'r') as f:
+    if currency_file.exists():
+        with currency_file.open('r') as f:
             existing_data = f.readlines()
         existing_dates = {line.split(',')[0] for line in existing_data}
     else:
@@ -286,22 +287,25 @@ def update_currency_rates(dates_and_rates):
                 updated_data.append(f'{date_str},{rate},{cbr_rate},{diff}\n')
 
     # Запись обновленных данных в файл
-    with open(currency_file, 'a') as f:
+    with currency_file.open('a') as f:
         f.writelines(updated_data)
 
 # Чтение данных из файла конфигурации для экспорта сообщений
 from config import PRIVATE_DIR
 
 config = ConfigParser()
-config.read(os.path.join(PRIVATE_DIR, 'currency_config.ini'))
+config_path = PRIVATE_DIR / 'currency_config.ini'
+config.read(config_path)
 
 api_id = config.getint('telegram', 'api_id')
 api_hash = config.get('telegram', 'api_hash')
 phone = config.get('telegram', 'phone')
 session_name = config.get('telegram', 'session_name')
+session_path = Path(PRIVATE_DIR) / session_name
+session_path.parent.mkdir(parents=True, exist_ok=True)
 
 # Создаем клиента для экспорта сообщений
-client = TelegramClient(session_name, api_id, api_hash)
+client = TelegramClient(str(session_path), api_id, api_hash)
 
 # Включаем логирование для экспорта сообщений
 logging.basicConfig(level=logging.INFO)

--- a/my_libs/tg_boyard/tg_boyatd_chat_parser.py
+++ b/my_libs/tg_boyard/tg_boyatd_chat_parser.py
@@ -1,7 +1,7 @@
-import os
 import json
 import random
 import unicodedata
+from pathlib import Path
 from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
 from telethon.tl.functions.messages import GetHistoryRequest
@@ -23,19 +23,19 @@ chat_id = creds.get('chat_id')
 polling_interval = 10
 
 # Получаем директорию, где находится скрипт
-script_dir = os.path.dirname(os.path.abspath(__file__))
+script_dir = Path(__file__).resolve().parent
 
 # Файл для сохранения реакций (полный путь)
-reactions_file = os.path.join(script_dir, 'reactions.json')
+reactions_file = script_dir / 'reactions.json'
 
 # Файл с ответами (полный путь)
-messages_file = os.path.join(script_dir, 'messages.txt')
+messages_file = script_dir / 'messages.txt'
 
 # Функция для загрузки сохранённых реакций из файла
 def load_reactions():
-    if os.path.exists(reactions_file):
+    if reactions_file.exists():
         try:
-            with open(reactions_file, 'r', encoding='utf-8') as file:
+            with reactions_file.open('r', encoding='utf-8') as file:
                 reactions = json.load(file)
                 return reactions
         except json.JSONDecodeError:
@@ -45,14 +45,14 @@ def load_reactions():
 
 # Функция для сохранения реакций в файл
 def save_reactions(reactions):
-    with open(reactions_file, 'w', encoding='utf-8') as file:
+    with reactions_file.open('w', encoding='utf-8') as file:
         json.dump(reactions, file, ensure_ascii=False, indent=4)
 
 # Функция для загрузки сообщений из файла messages.txt
 def load_messages():
-    if os.path.exists(messages_file):
+    if messages_file.exists():
         try:
-            with open(messages_file, 'r', encoding='utf-8') as file:
+            with messages_file.open('r', encoding='utf-8') as file:
                 lines = [line.strip() for line in file if line.strip()]
                 return lines
         except Exception as e:
@@ -63,7 +63,10 @@ def load_messages():
         return []
 
 async def main():
-    client = TelegramClient('session_name', api_id, api_hash)
+    session_name = creds.get('session_name', 'tg_boyard_session')
+    session_path = PRIVATE_DIR / session_name
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    client = TelegramClient(str(session_path), api_id, api_hash)
     await client.start()
 
     if not await client.is_user_authorized():


### PR DESCRIPTION
## Summary
- Build data and session file paths with `pathlib.Path` for consistent behavior on macOS and Windows
- Ensure Telethon session directories exist before client creation

## Testing
- `python -m py_compile my_libs/currency/chat_analysis.py my_libs/currency/channel_tester.py handlers/users/purchase.py my_libs/tg_boyard/tg_boyatd_chat_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_689b68bf0f6883279deea448bfb0b334